### PR TITLE
Add basic menu structure [Closes #31]

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -1,5 +1,6 @@
 angular.module('artemis', [
   'artemis.auth',
+  'artemis.menu',
   'artemis.services',
   'ui.router'
 ])
@@ -9,8 +10,13 @@ angular.module('artemis', [
   $stateProvider
     .state('menu', {
       url: '/menu',
-      templateUrl: '',
+      templateUrl: 'app/menu/menu.html',
       controller: 'MenuController'
+    })
+    .state('menu.create', {
+      url: '/create',
+      templateUrl: 'app/menu/create/create.html',
+      controller: 'CreateController'
     })
     .state('board', {
       url: '/board',

--- a/client/app/menu/create/create.html
+++ b/client/app/menu/create/create.html
@@ -1,0 +1,7 @@
+<form>
+  Name of deceased
+  <input type="text" ng-model="deceasedName" placeholder="name">
+  <button ng-click="invite()">Invite</button>
+  <button ng-click="cancel()">Cancel</button>
+  <button ng-click="create()">Create</button>
+</form>

--- a/client/app/menu/create/create.js
+++ b/client/app/menu/create/create.js
@@ -1,0 +1,29 @@
+angular.module('artemis.menu.create', [
+
+])
+.controller('CreateController', function($scope, $state, $window, Boards) {
+  $scope.invite = function() {
+    console.log('Invite UI');
+    // TODO: some way to invite users via email or fb
+  };
+
+  $scope.create = function() {
+    // --- testing
+    console.log('Board created. Back to menu');
+    $state.go('menu');
+
+    // --- dev
+    // var params = {
+    //   deceasedName: $scope.deceasedName,
+    //   creator: user, // TODO
+    //   guests: [users], // TODO
+    // };
+    // Boards.createBoard(params).then(function(board) {
+    //   $state.go('menu');
+    // });
+  };
+
+  $scope.cancel = function() {
+    $state.go('menu');
+  };
+});

--- a/client/app/menu/menu.html
+++ b/client/app/menu/menu.html
@@ -1,0 +1,9 @@
+<button ng-click="create()" ng-show="isState('menu')">Create new board</button>
+<div ui-view></div>
+
+<div class="container">
+  <div class="board" ng-repeat="board in boards | orderBy:'-createdAt'">
+    <img src="http://www.kabwemunicipality.org/wp-content/uploads/2015/05/placeholder.jpg"/>
+    <a href="{{ board.url }}" class="title">{{ board.deceasedName }}</a>
+  </div>
+</div>

--- a/client/app/menu/menu.js
+++ b/client/app/menu/menu.js
@@ -1,0 +1,37 @@
+angular.module('artemis.menu', [
+  'artemis.menu.create'
+])
+.controller('MenuController', function($scope, $state, Boards) {
+  // --- testing
+  $scope.boards = [
+    {
+      deceasedName: 'Ned Stark',
+      url: 'http://www.google.com'
+    },
+    {
+      deceasedName: 'Tywin Lannister',
+      url: 'http://www.amazon.com'
+    },
+    {
+      deceasedName: 'The Hound',
+      url: 'http://www.apple.com'
+    }
+  ];
+
+  $scope.create = function() {
+    $state.go('menu.create');
+  };
+
+  $scope.getBoards = function() {
+    Boards.getBoards().then(function(response) {
+      $scope.boards = response.data; // TODO: conform to Parse API
+    });
+  };
+
+  $scope.isState = function(name) {
+    return $state.current.name === name;
+  };
+
+  // initialize board
+  // $scope.getBoards();
+});

--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -20,4 +20,31 @@ angular.module('artemis.services', [])
 
   };
 
+  return {
+    signin: signin,
+    signup: signup,
+    isAuth: isAuth,
+    signout: signout
+  };
+})
+.factory('Boards', function($http) {
+  var getBoards = function(user) {
+    // user = { username, password }
+    // get boards that are owned/administered by the user
+  };
+
+  var createBoard = function(data) {
+    // create board
+  };
+
+  var checkAccess = function(user, board) {
+    // return a promise that resolves into a boolean
+    // indicating whether or not the user has access to the board
+  };
+
+  return {
+    getBoards: getBoards,
+    createBoard: createBoard,
+    checkAccess: checkAccess
+  };
 });

--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Artemis</title>
     <script src="config.js"></script>
+    <link rel="stylesheet" type="text/css" href="styles/styles.css"/>
   </head>
   <body>
     <div ui-view></div>
@@ -14,6 +15,8 @@
     <script src="app/auth/auth.js"></script>
     <script src="app/auth/signin/signin.js"></script>
     <script src="app/auth/signup/signup.js"></script>
+    <script src="app/menu/menu.js"></script>
+    <script src="app/menu/create/create.js"></script>
     <script src="app/board/board.js"></script>
     <script src="app/services/services.js"></script>
     <script src="app/app.js"></script>

--- a/client/styles/styles.css
+++ b/client/styles/styles.css
@@ -1,0 +1,14 @@
+.board {
+  display: inline-block;
+  width: 360px;
+  height: 360px;
+}
+
+.board img {
+  width: 100%;
+  height: 100%;
+}
+
+.board .title {
+  display: inline-block;
+}


### PR DESCRIPTION
Menu:
- Go to /#/menu  to see sample array of boards
- Click on a board to go to that board (currently linked to dummy links)
- Includes a **create** button to enter `menu.create` state

Menu.create:
- **Create** new boards (currently only requires name of deceased)
- **Cancel** to return to `menu` state
- **Invite** guests to newly created board (not yet implemented)

Other:
- Defined some functions needed for `menu` state under `Boards` service. These are not yet implemented.

Connects to #7 
