### PR TITLE
Improvements to build system for angular, browser reloading and docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - '0.10'
+  - '0.12'
 before_install: npm install -g gulp
 install: npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian
+
+RUN apt-get update && apt-get -y install curl git
+
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+
+ENV NODE_VERSION 0.12.7
+ENV NPM_VERSION latest
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --verify SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - \
+  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc \
+  && npm install -g npm@"$NPM_VERSION" \
+  && npm cache clear
+
+WORKDIR /app
+ENV NODE_ENV production
+ADD package.json package.json
+RUN npm install --production
+
+ADD dist dist
+ADD server server
+
+EXPOSE 4568
+CMD ["npm", "start"]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,9 @@ var cheerio = require('gulp-cheerio');
 var nodemon = require('gulp-nodemon');
 var eslint = require('gulp-eslint');
 var angularTemplates = require('gulp-angular-templates');
+var browserSync = require('browser-sync');
 var pjson = require('./package.json');
+var reload = browserSync.reload;
 
 gulp.task('bower', function() {
   return bower({ cmd: 'update'});
@@ -65,11 +67,25 @@ gulp.task('lint', function() {
 
 gulp.task('test', ['lint']);
 
-gulp.task('watch', function() {
+gulp.task('watch:server', function() {
   nodemon({
     script: pjson.main,
-    ext: 'js html'
+    ext: 'js'
   });
 });
+
+gulp.task('watch:client', function() {
+  browserSync({
+    server: {
+      baseDir: 'client'
+    }
+  });
+
+  gulp.watch(['client/**/*.html', 'client/**/*.css', 'client/**/*.js'], reload);
+});
+
+// since we're using parse api at the moment we don't need to
+// run our server
+gulp.task('watch', ['watch:client']);
 
 gulp.task('default', ['watch']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 var gulp = require('gulp');
+var bower = require('gulp-bower');
 var domSrc = require('gulp-dom-src');
 var concat = require('gulp-concat');
 var cssmin = require('gulp-cssmin');
@@ -7,7 +8,20 @@ var minifyHTML = require('gulp-minify-html');
 var cheerio = require('gulp-cheerio');
 var nodemon = require('gulp-nodemon');
 var eslint = require('gulp-eslint');
+var angularTemplates = require('gulp-angular-templates');
 var pjson = require('./package.json');
+
+gulp.task('bower', function() {
+  return bower({ cmd: 'update'});
+});
+
+gulp.task('build:templates', function() {
+  return gulp.src('client/app/**/*.html')
+    .pipe(angularTemplates({module: 'artemis', basePath: 'app/'}))
+    .pipe(concat('app.templates.min.js'))
+    .pipe(uglify({mangle: false}))
+    .pipe(gulp.dest('dist/'));
+});
 
 gulp.task('build:css', function() {
   return domSrc({file:'client/index.html', selector:'link', attribute:'href'})
@@ -19,7 +33,7 @@ gulp.task('build:css', function() {
 gulp.task('build:js', function() {
   return domSrc({file:'client/index.html', selector:'script', attribute:'src'})
     .pipe(concat('app.full.min.js'))
-    .pipe(uglify())
+    .pipe(uglify({mangle: false}))
     .pipe(gulp.dest('dist/'));
 });
 
@@ -29,13 +43,18 @@ gulp.task('build:indexHtml', function() {
       $('script').remove();
       $('link').remove();
       $('body').append('<script src="app.full.min.js"></script>');
+      $('body').append('<script src="app.templates.min.js"></script>');
       $('head').append('<link rel="stylesheet" href="app.full.min.css">');
     }))
     .pipe(minifyHTML())
     .pipe(gulp.dest('dist/'));
 });
 
-gulp.task('build', ['build:css', 'build:js', 'build:indexHtml']);
+gulp.task('build:all', ['build:css', 'build:js', 'build:templates', 'build:indexHtml']);
+
+gulp.task('build', ['bower'], function() {
+  return gulp.start('build:all');
+});
 
 gulp.task('lint', function() {
   return gulp.src(['*.js', 'client/**/*.js', '!client/bower_components/**/*.js', 'server/**/*.js'])
@@ -49,8 +68,7 @@ gulp.task('test', ['lint']);
 gulp.task('watch', function() {
   nodemon({
     script: pjson.main,
-    ext: 'js html',
-    env: { 'NODE_ENV': 'development' }
+    ext: 'js html'
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "express": "^4.4.5"
   },
   "devDependencies": {
+    "browser-sync": "^2.8.2",
     "eslint": "^1.0.0",
     "gulp": "^3.9.0",
     "gulp-angular-templates": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "devDependencies": {
     "eslint": "^1.0.0",
     "gulp": "^3.9.0",
+    "gulp-angular-templates": "0.0.2",
+    "gulp-bower": "0.0.10",
     "gulp-cheerio": "^0.6.2",
     "gulp-concat": "^2.6.0",
     "gulp-cssmin": "^0.1.7",


### PR DESCRIPTION
Updated build task to work with angular. Requires a additional build step to compile the templates to js and adding them to the angular template cache. Name mangling needs to be disabled since angular relies on those for dependency injection.

By running `gulp watch` we start the browser sync server that serves our static files from /client. Since we're using the parse api at the moment, we don't need to run our express server. When we do we'll have to use the express cors module to allow access from our client that is served by browser sync during developement.

Added and tested a dockerfile, so that we can continuously deploy using our continuous integration system. Travis CI doesn't support docker at the moment, since our CI has to run

```
gulp build
docker build -t artemis .
docker push to a docker registry like tutum
```

from there tutum then automatically deploys to our VPS.

Connects to #16 
