### PR TITLE
(fix) Fixed getPosts params to specify boardId pointer

### DIFF
--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -71,7 +71,17 @@ angular.module('artemis.services', [])
 
 .factory('Posts', function($http) {
   var getPosts = function(boardId) {
-    return $http.get('https://api.parse.com/1/classes/Post', {where: {boardId: boardId}})
+    return $http.get('https://api.parse.com/1/classes/Post', {
+      params: {
+        where: {
+          boardId: {
+            className: 'Board',
+            '__type': 'Pointer',
+            objectId: boardId
+          }
+        }
+      }
+    })
       .error(function(err) {
         console.error(err);
       });


### PR DESCRIPTION
Using params allows us to send data in a GET request, as Angular will encode the data into the url. The boardId is actually a reference to a Pointer object in Parse, so passing in a string does not work. You have to pass an object with the correct fields - [documentation for Pointer type is here.](https://parse.com/docs/rest/guide#objects-data-types)

Let me know if the formatting is a problem. I didn't want to flatten it on one line because it looked confusing, but it does take up 10 lines.

Closes #52 
