### PR TITLE
Client side route restrictions

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -1,30 +1,26 @@
 angular.module('artemis', [
   'artemis.auth',
-  'artemis.home',
+  'artemis.menu',
   'artemis.services',
   'ui.router'
 ])
 .config(function($stateProvider, $urlRouterProvider, $httpProvider) {
-  $urlRouterProvider.otherwise('/auth/signin');
+  $urlRouterProvider.otherwise('/menu');
 
   $stateProvider
-    .state('home', {
-      templateUrl: 'app/home/home.html',
-      controller: 'HomeController'
-    })
-    .state('home.menu', {
+    .state('menu', {
       url: '/menu',
       templateUrl: 'app/home/menu/menu.html',
-      controller: 'MenuController'
+      controller: 'MenuController',
     })
-    .state('home.menu.create', {
+    .state('menu.create', {
       url: '/create',
       templateUrl: 'app/home/menu/create/create.html',
       controller: 'CreateController'
     })
-    .state('home.board', {
-      url: '/board/:id',
-      templateUrl: 'app/home/board/board.html',
+    .state('board', {
+      url: '/board',
+      templateUrl: '',
       controller: 'BoardController'
     })
     .state('auth', {

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -59,4 +59,14 @@ angular.module('artemis', [
     }
   };
   return attach;
+})
+.run(function ($rootScope, $location, $state, Users) {
+  $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) {
+    if(toState.name === 'auth.signup' || toState.name === 'auth.signin'){
+      //do nothing
+    } else if (!Users.isAuth()) {
+      event.preventDefault();
+      $state.go('auth.signin');
+    }
+  });
 });

--- a/client/app/auth/signin/signin.js
+++ b/client/app/auth/signin/signin.js
@@ -6,10 +6,10 @@ angular.module('artemis.auth.signin', [])
       username: $scope.username,
       password: $scope.password
     })
-    .then(function() {
-      $state.go('home.menu');
+    .success(function() {
+      $state.go('menu');
     })
-    .catch(function(err) {
+    .error(function(err) {
       console.error(err);
     });
   };

--- a/client/app/auth/signup/signup.js
+++ b/client/app/auth/signup/signup.js
@@ -7,10 +7,10 @@ angular.module('artemis.auth.signup', [])
       email: $scope.email,
       password: $scope.password
     })
-    .then(function() {
+    .success(function() {
       $state.go('auth.signin');
     })
-    .catch(function() {
+    .error(function() {
 
     });
   };

--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -1,11 +1,15 @@
-angular.module('artemis.services', [])
+angular.module('artemis.services', ['ngCookies'])
 
-.factory('Users', function($http) {
+.factory('Users', function($http, $cookies) {
   var signin = function(user) {
     return $http.get('https://api.parse.com/1/login', {params: user})
-      .error(function(err) {
-        console.error(err);
-      });
+    .success(function(res) {
+      $cookies.put('sessionToken', res.sessionToken);
+      $cookies.put('userId', res.objectId);
+    })
+    .error(function(res) {
+
+    });
   };
 
   var signup = function(user) {
@@ -16,7 +20,7 @@ angular.module('artemis.services', [])
   };
 
   var isAuth = function() {
-
+    return !!$cookies.get('sessionToken');
   };
 
   var signout = function() {

--- a/client/index.html
+++ b/client/index.html
@@ -9,12 +9,12 @@
     <div ui-view></div>
 
     <script src="bower_components/angular/angular.js"></script>
+    <script src="bower_components/angular-cookies/angular-cookies.js"></script>
     <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
 
     <script src="app/auth/auth.js"></script>
     <script src="app/auth/signin/signin.js"></script>
     <script src="app/auth/signup/signup.js"></script>
-    <script src="app/home/home.js"></script>
     <script src="app/home/menu/menu.js"></script>
     <script src="app/home/menu/create/create.js"></script>
     <script src="app/home/board/board.js"></script>


### PR DESCRIPTION
Bug fixes: Fixed outdated state names referencing "home." and invalid script tags. These needed to be fixed in order to implement our solution.

Feature: We stored the userId and sessionToken on the client using cookies. At each state change the sessionToken is checked to see if the user has already been "authenticated" and if they are not, we redirect them to the signin state. Keep in mind, we are currently only checking for the presence of the session token and not the validity of the token itself.
![cookies](https://cloud.githubusercontent.com/assets/9373803/9179836/9f4efd66-3f64-11e5-8d7c-91dd34644497.png)

They are not currently being stored in the header.
