### PR TITLE
( feat ) Implemented client-side route restrictions [Closes #41]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - '0.10'
+before_install: npm install -g gulp
+install: npm install

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -63,4 +63,14 @@ angular.module('artemis', [
     }
   };
   return attach;
+})
+.run(function ($rootScope, $location, $state, Users) {
+  $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) {
+    if (toState.name === 'auth.signup' || toState.name === 'auth.signin') {
+      //do nothing
+    } else if (!Users.isAuth()) {
+      event.preventDefault();
+      $state.go('auth.signin');
+    }
+  });
 });

--- a/client/app/auth/signin/signin.js
+++ b/client/app/auth/signin/signin.js
@@ -6,10 +6,10 @@ angular.module('artemis.auth.signin', [])
       username: $scope.username,
       password: $scope.password
     })
-    .then(function() {
+    .success(function() {
       $state.go('home.menu');
     })
-    .catch(function(err) {
+    .error(function(err) {
       console.error(err);
     });
   };

--- a/client/app/auth/signup/signup.js
+++ b/client/app/auth/signup/signup.js
@@ -7,10 +7,10 @@ angular.module('artemis.auth.signup', [])
       email: $scope.email,
       password: $scope.password
     })
-    .then(function() {
+    .success(function() {
       $state.go('auth.signin');
     })
-    .catch(function() {
+    .error(function() {
 
     });
   };

--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -1,11 +1,15 @@
-angular.module('artemis.services', [])
+angular.module('artemis.services', ['ngCookies'])
 
-.factory('Users', function($http) {
+.factory('Users', function($http, $cookies) {
   var signin = function(user) {
     return $http.get('https://api.parse.com/1/login', {params: user})
-      .error(function(err) {
-        console.error(err);
-      });
+    .success(function(res) {
+      $cookies.put('sessionToken', res.sessionToken);
+      $cookies.put('userId', res.objectId);
+    })
+    .error(function(res) {
+
+    });
   };
 
   var signup = function(user) {
@@ -16,7 +20,7 @@ angular.module('artemis.services', [])
   };
 
   var isAuth = function() {
-
+    return !!$cookies.get('sessionToken');
   };
 
   var signout = function() {

--- a/client/index.html
+++ b/client/index.html
@@ -10,6 +10,7 @@
 
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
+    <script src="bower_components/angular-cookies/angular-cookies.js"></script>
 
     <script src="app/auth/auth.js"></script>
     <script src="app/auth/signin/signin.js"></script>


### PR DESCRIPTION
We stored the userId and sessionToken on the client using cookies. At each state change the sessionToken is checked to see if the user has already been "authenticated" and if they are not, we redirect them to the signin state. Keep in mind, we are currently only checking for the presence of the session token and not the validity of the token itself.

![cookies](https://cloud.githubusercontent.com/assets/9373803/9187585/f72ac500-3f97-11e5-9f2c-6f94f3ebf1d6.png)
