### PR TITLE
( feat ) Implement Parse ACL authorization [Closes #53]

### DIFF
--- a/client/app/home/menu/menu.js
+++ b/client/app/home/menu/menu.js
@@ -1,7 +1,7 @@
 angular.module('artemis.menu', [
   'artemis.menu.create'
 ])
-.controller('MenuController', function($scope, $state, Boards) {
+.controller('MenuController', function($scope, $state, Boards, Users) {
   $scope.boards = [];
 
   $scope.create = function() {
@@ -9,7 +9,8 @@ angular.module('artemis.menu', [
   };
 
   $scope.getBoards = function() {
-    Boards.getBoards().then(function(res) {
+    var token = Users.getSessionToken();
+    Boards.getBoards(token).then(function(res) {
       $scope.boards = res.data.results;
     });
   };

--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -23,6 +23,10 @@ angular.module('artemis.services', ['ngCookies'])
     return !!$cookies.get('sessionToken');
   };
 
+  var getSessionToken = function() {
+    return $cookies.get('sessionToken');
+  };
+
   var signout = function() {
     // remove anything that should be removed from local storage
     // transition user to sign in page
@@ -32,7 +36,8 @@ angular.module('artemis.services', ['ngCookies'])
     signin: signin,
     signup: signup,
     isAuth: isAuth,
-    signout: signout
+    signout: signout,
+    getSessionToken: getSessionToken
   };
 })
 
@@ -44,12 +49,20 @@ angular.module('artemis.services', ['ngCookies'])
       });
   };
 
-  var getBoards = function(user) {
+  var getBoards = function(token, user) {
     // user = { username, password }
     // TODO: get boards that are owned/administered by the user
-    return $http.get('https://api.parse.com/1/classes/Board')
+    var req = {
+      method: 'GET',
+      url: 'https://api.parse.com/1/classes/Board',
+      headers: {
+        'X-Parse-Session-Token': token
+      }
+    };
+    return $http(req)
       .error(function(err) {
-        console.error(err);
+        //TODO: error handling
+        console.log(err);
       });
   };
 


### PR DESCRIPTION
The formatting for the `getBoards()` factory function was changed to support custom headers (see: https://code.angularjs.org/1.4.3/docs/api/ng/service/$http). There was also an additional parameter added called `token` and Users token is sent in to be attached to the header. 

In order to get the users token, I also added a `getSessionToken()` factory function to the `Users` factor.
