### PR TITLE
( cleanup ) Replaced deprecated $http methods [Closes #70]

### DIFF
--- a/client/app/auth/signin/signin.js
+++ b/client/app/auth/signin/signin.js
@@ -6,11 +6,8 @@ angular.module('artemis.auth.signin', [])
       username: $scope.username,
       password: $scope.password
     })
-    .success(function() {
+    .then(function() {
       $state.go('home.menu');
-    })
-    .error(function(err) {
-      console.error(err);
     });
   };
 });

--- a/client/app/auth/signup/signup.js
+++ b/client/app/auth/signup/signup.js
@@ -7,11 +7,8 @@ angular.module('artemis.auth.signup', [])
       email: $scope.email,
       password: $scope.password
     })
-    .success(function() {
+    .then(function(res) {
       $state.go('auth.signin');
-    })
-    .error(function() {
-
     });
   };
 });

--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -3,20 +3,21 @@ angular.module('artemis.services', ['ngCookies'])
 .factory('Users', function($http, $cookies) {
   var signin = function(user) {
     return $http.get('https://api.parse.com/1/login', {params: user})
-    .success(function(res) {
-      $cookies.put('sessionToken', res.sessionToken);
-      $cookies.put('userId', res.objectId);
-    })
-    .error(function(res) {
-
-    });
+      .then(function(res) {
+        $cookies.put('sessionToken', res.data.sessionToken);
+        $cookies.put('userId', res.data.objectId);
+      }, function(res) {
+        console.error(res.data);
+      });
   };
 
   var signup = function(user) {
     return $http.post('https://api.parse.com/1/classes/_User', user)
-      .error(function(err) {
-        console.error(err);
-      });
+    .then(function(res) {
+      //success
+    }, function(res) {
+      console.error(res.data);
+    });
   };
 
   var isAuth = function() {
@@ -44,8 +45,10 @@ angular.module('artemis.services', ['ngCookies'])
 .factory('Boards', function($http) {
   var getBoard = function(id) {
     return $http.get('https://api.parse.com/1/classes/Board', {where: {objectId: id}})
-      .error(function(err) {
-        console.log(err);
+      .then(function(res) {
+        return res;
+      }, function(res) {
+        console.error(res.data);
       });
   };
 
@@ -60,16 +63,19 @@ angular.module('artemis.services', ['ngCookies'])
       }
     };
     return $http(req)
-      .error(function(err) {
-        //TODO: error handling
-        console.log(err);
+      .then(function(res) {
+        return res;
+      }, function(res) {
+        console.error(res.data);
       });
   };
 
   var createBoard = function(data) {
     return $http.post('https://api.parse.com/1/classes/Board', data)
-      .error(function(err) {
-        console.error(err);
+    .then(function(res) {
+
+    }, function(res) {
+        console.error(res.data);
       });
   };
 
@@ -99,8 +105,10 @@ angular.module('artemis.services', ['ngCookies'])
         }
       }
     })
-      .error(function(err) {
-        console.error(err);
+      .then(function(res) {
+        return res;
+      }, function(res) {
+        console.error(res.data);
       });
   };
 


### PR DESCRIPTION
Replaced deprecated $http methods `.success()` and `.error()` with .then() [Closes #70]

This changed the way that our factory functions interact with the controllers they are injected to. The `.then()` method only has one parameter `response` which we have named `res`. This is different than `.success()` and `.error()` which had 4 parameters `data, status, header, config`. Now in order to access these properties you need to explicitly say `res.data` etc. 

In order to keep the controllers functioning properly we had to return the `res` after the promise completed so the controller functions still had access to the appropriate data (See: menu.js 13 - 15). 

Based on this, I would like to suggest that we handle accessing the `res.data.<pertinent property>` in the factory functions and return the data we want to our controllers. This removes the mess of dealing with `res` objects in multiple files and could make for more understandable code. Compare this example with the PR: 
## services.js getboards()

```
var getBoards = function(token, user) {
   //setting up the req
    return $http(req)
      .then(function(res) {
        //Current version: return res;
        return res.data.results; 
      }, function(res) {
        //error block
      });
  };
```
## menu.js MenuController

```
$scope.getBoards = function() {
    var token = Users.getSessionToken();
    Boards.getBoards(token).then(function(boards) {
      //Current version: $scope.boards = res.data.results;
      $scope.boards = boards;
    });
  };
```

Side note regarding error checking on http requests: I removed the error function handling from the files outside of `services.js` so that we can just handle errors right where they happen.
