### PR TITLE
( feat ) Destroy cookies on logout [Closes #69]

### DIFF
--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -30,8 +30,27 @@ angular.module('artemis.services', ['ngCookies'])
 
   var signout = function() {
     // remove anything that should be removed from local storage
+    var token = $cookies.get('sessionToken');
     $cookies.remove('sessionToken');
     $cookies.remove('userId');
+
+    var req = {
+      method: 'POST',
+      url: 'https://api.parse.com/1/logout',
+      headers: {
+        'X-Parse-Session-Token': token
+      }
+    };
+
+    return $http(req)
+      .then(function(res) {
+        //success
+        console.log(res);
+      }, function(res) {
+        console.error(res.data);
+      });
+
+
   };
 
   return {

--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -30,7 +30,8 @@ angular.module('artemis.services', ['ngCookies'])
 
   var signout = function() {
     // remove anything that should be removed from local storage
-    // transition user to sign in page
+    $cookies.remove('sessionToken');
+    $cookies.remove('userId');
   };
 
   return {


### PR DESCRIPTION
This one is pretty simple, just uses the `.remove()` method from `$cookies` to get rid of the `sessionToken` and `userId` locally. To remove them from the Parse database, we just send a `POST` request to the logout endpoint with the sessionToken in the header
