### PR TITLE
( feat ) Confirm passwords match on signup page [Closes #89]

### DIFF
--- a/client/app/auth/signup/signup.html
+++ b/client/app/auth/signup/signup.html
@@ -12,6 +12,9 @@
     <div class="form-group">
       <input type="password" placeholder="Password" ng-model="password" class="form-control">
     </div>
+    <div class="form-group">
+        <input type="password" placeholder="Confirm password" ng-model="passwordConfirm" class="form-control">
+    </div>
   </div>
   <div class="submit-container">
     <button type="submit" class="btn btn-success submit">Sign up</button>

--- a/client/app/auth/signup/signup.js
+++ b/client/app/auth/signup/signup.js
@@ -2,13 +2,17 @@ angular.module('artemis.auth.signup', [])
 
 .controller('SignUpController', function($scope, $window, $state, Users) {
   $scope.signup = function() {
-    Users.signup({
-      username: $scope.username,
-      email: $scope.email,
-      password: $scope.password
-    })
-    .then(function(res) {
-      $state.go('auth.signin');
-    });
+    if ($scope.password === $scope.passwordConfirm) {
+      Users.signup({
+        username: $scope.username,
+        email: $scope.email,
+        password: $scope.password
+      })
+      .then(function(res) {
+        $state.go('auth.signin');
+      });
+    } else {
+      //Display passwords do not match to user
+    }
   };
 });


### PR DESCRIPTION
Added a confirm password input field and a simple check that the passwords match in the `SignUpController`. Left the else block intentionally blank with a comment so the UI for displaying the error to the user can be implemented.
