### PR TITLE
(feat) Add board styling and menu

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,9 @@
     "angular-cookies": "~1.4.3",
     "ng-file-upload": "~6.0.4",
     "bootstrap": "~3.3.5",
-    "angular-bootstrap": "~0.13.3"
+    "angular-bootstrap": "~0.13.3",
+    "angular-deckgrid": "~0.5.0",
+    "angular-timeago": "~0.2.0"
   },
   "ignore": [
     "**/.*",

--- a/client/app/home/board/board.html
+++ b/client/app/home/board/board.html
@@ -1,8 +1,28 @@
-<h1>{{ board.deceasedName }}</h1>
+<nav class="navbar navbar-default">
+  <div class="container-fluid">
+    <!-- Brand and toggle get grouped for better mobile display -->
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" ui-sref="home.menu">ForeverBoard</a>
+    </div>
+    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+      <ul class="nav navbar-nav">
+        <li><a href="" ng-click="create()">Create Post</a></li>
+        <li><a href="" ng-click="invite()">Invite to Board</a></li>
+        <li><a href="" ng-click="signout()">Signout</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
 
-<button ng-click="invite()">Invite guests</button>
-<button ng-click="create()">Create new post</button>
-
-<div class="post-container">
-  <post source="post" ng-repeat="post in posts | orderBy: '-createdAt'"></post>
+<div class="deceased-info">
+  <img class="deceased-photo" src="{{ board.photo }}" />
+  <h1 class="deceased-name">{{ board.deceasedName }}</h1>
 </div>
+
+<div deckgrid source="posts" cardTemplate="app/home/board/post.html" class="deckgrid"></div>

--- a/client/app/home/board/board.js
+++ b/client/app/home/board/board.js
@@ -1,6 +1,8 @@
 angular.module('artemis.board', [
   'artemis.board.create',
-  'artemis.board.invite'
+  'artemis.board.invite',
+  'akoenig.deckgrid',
+  'yaru22.angular-timeago'
 ])
 
 .controller('BoardController', function($scope, $stateParams, $state, $modal, $q, Users, Boards, Posts) {
@@ -77,21 +79,4 @@ angular.module('artemis.board', [
 
   $scope.getBoard();
   $scope.getPosts();
-})
-.directive('post', function() {
-  return {
-    restrict: 'EA', // can be used as Element or Attribute
-    templateUrl: 'app/home/board/post.html',
-    replace: true, // replaces the directive tags in the DOM
-    scope: { // defining object literal -> isolate scope (does not delegate upwards to parents)
-      source: '='
-      // '=' -> 2-way binding to whatever I designate as 'source', can be object/array
-      // '@' means 1-way binding (changes in directive do not change outside)
-      // '&' means passing in a function
-    },
-    link: function(scope, ele, attr) {
-      // do stuff here
-      console.log('post');
-    }
-  };
 });

--- a/client/app/home/board/post.html
+++ b/client/app/home/board/post.html
@@ -1,6 +1,8 @@
 <div class="post">
-  <div class="username">{{ source.username }}</div>
-  <div class="timestamp">{{ source.createdAt }}</div>
-  <img class="photo" ng-src="{{ source.photo }}"/>
-  <div class="content">{{ source.content }}</div>
+  <img class="photo" ng-src="{{ card.photo }}"/>
+  <div class="content">{{ card.content }}</div>
+  <div class="post-footer">
+    <div class="username"><h5>{{ card.userId.username }}</h5></div>
+    <div class="timestamp"><h6>{{ card.createdAt | timeAgo }}</h6></div>
+  </div>
 </div>

--- a/client/app/services/services.js
+++ b/client/app/services/services.js
@@ -122,7 +122,10 @@ angular.module('artemis.services', ['ngCookies'])
             __type: 'Pointer',
             objectId: boardId
           }
-        }
+        },
+        // userId points to the relevant User in Parse
+        // This will grab the User's data instead of simply a reference
+        include: 'userId'
       }
     })
       .then(function(res) {

--- a/client/index.html
+++ b/client/index.html
@@ -15,6 +15,8 @@
     <script src="bower_components/angular-bootstrap/ui-bootstrap.min.js"></script>
     <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
     <script src="bower_components/ng-file-upload/ng-file-upload.js"></script>
+    <script src="bower_components/angular-deckgrid/angular-deckgrid.js"></script>
+    <script src="bower_components/angular-timeago/dist/angular-timeago.js"></script>
     <script src="app/auth/auth.js"></script>
     <script src="app/auth/signin/signin.js"></script>
     <script src="app/auth/signup/signup.js"></script>

--- a/client/styles/styles.css
+++ b/client/styles/styles.css
@@ -28,9 +28,47 @@
   border-radius: 150px;
   margin-bottom: 50px;
 }
+
+.deceased-info {
+  width: 21%;
+  /* In line with ForeverBoard menu title */
+  margin-left: 15px;
+  margin-right: 2%;
+  float: left;
+}
+
+.deceased-photo, .post .photo {
+  max-width: 100%;
+}
+
 .post {
-  display: inline-block;
-  margin: 20px;
+  border: 1px solid #DEDEDE;
+  border-radius: 5px;
+  margin-bottom: 10px;
+  padding: 0 5px;
+  text-align: center;
+  color: #777;
+}
+
+.post .photo {
+  margin-bottom: 10px;
+}
+
+.deckgrid[deckgrid]::before {
+  /* Specifies that the grid should have a maximum of 3 columns.
+  Each column will have the classes 'column' and 'column-1-3' */
+  content: '3 .column.column-1-3';
+  font-size: 0; /* See https://github.com/akoenig/angular-deckgrid/issues/14#issuecomment-35728861 */
+  visibility: hidden;
+}
+
+.deckgrid .column {
+  float: left;
+}
+
+.deckgrid .column-1-3 {
+  width: 23%;
+  margin-right: 2%;
 }
 
 .main-container {


### PR DESCRIPTION
- Added angular-deckgrid and angular-timeago deps
- Deckgrid replaces the Posts directive for generating the layout of the posts, but still uses the post.html as a template
- `card` is the object provided by deckgrid that refers to each post in the posts model

The menu is currently being duplicated with specific options for the Menu view and the Board view. This needs to be refactored into the Home view, but it will take a bit of work with scoping, so I'm leaving it out of this PR.

Closes #35 

![screen shot 2015-08-17 at 6 17 32 pm](https://cloud.githubusercontent.com/assets/12142496/9318130/b8617cc0-450e-11e5-9f10-7b3d0ab3b57e.png)
